### PR TITLE
Fix Test Suite

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,3 +5,4 @@ spring.kafka.consumer.enable-auto-commit=false
 spring.kafka.consumer.properties.isolation.level=read_committed
 
 logging.level.com.springsource=debug
+logging.level.org.apache.kafka=warn

--- a/src/test/java/com/springsource/open/foo/async/AbstractAsynchronousMessageTriggerTests.java
+++ b/src/test/java/com/springsource/open/foo/async/AbstractAsynchronousMessageTriggerTests.java
@@ -25,6 +25,7 @@ import com.springsource.open.foo.Handler;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -51,9 +52,10 @@ public abstract class AbstractAsynchronousMessageTriggerTests {
 	protected JdbcTemplate jdbcTemplate;
 
 	@BeforeEach
-	public void clearData(@Autowired KafkaAdmin admin, @Autowired KafkaListenerEndpointRegistry registry)
-			throws InterruptedException, ExecutionException, TimeoutException {
+	public void clearData(@Autowired KafkaAdmin admin, @Autowired KafkaListenerEndpointRegistry registry,
+			TestInfo testInfo) throws InterruptedException, ExecutionException, TimeoutException {
 
+		this.kafkaTemplate.setTransactionIdPrefix(testInfo.getDisplayName() + "-");
 		this.client = AdminClient.create(admin.getConfig());
 		this.client.deleteTopics(Collections.singletonList("async")).all().get(10, TimeUnit.SECONDS);
 		int n = 0;

--- a/src/test/java/com/springsource/open/foo/test/MessagingTests.java
+++ b/src/test/java/com/springsource/open/foo/test/MessagingTests.java
@@ -21,6 +21,7 @@ import java.time.Duration;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -42,7 +43,8 @@ public class MessagingTests {
 	private FooHandler consumer;
 
 	@BeforeEach
-	public void onSetUp(@Autowired KafkaListenerEndpointRegistry registry) throws Exception {
+	public void onSetUp(@Autowired KafkaListenerEndpointRegistry registry, TestInfo testInfo) throws Exception {
+		this.kafkaTemplate.setTransactionIdPrefix(testInfo.getDisplayName() + "-");
 		registry.getListenerContainer("group").start();
 		Thread.sleep(100L);
 		kafkaTemplate.executeInTransaction(t -> t.send("async", "foo"));


### PR DESCRIPTION
Some race in Kafka due to using the same tx-id in each test after
deleting/creating the topic.

>org.apache.kafka.common.errors.UnknownProducerIdException: This exception is raised by the broker if it could not locate the producer metadata associated with the producerId in question. This could happen if, for instance, the producer's records were deleted because their retention time had elapsed. Once the last records of the producerId are removed, the producer's metadata is removed from the broker, and future appends by the producer will return this exception.

Now the suite runs in STS, still errors running from maven.